### PR TITLE
feat: make miden-sdk path configurable using template variables

### DIFF
--- a/account/template/Cargo.toml
+++ b/account/template/Cargo.toml
@@ -10,7 +10,15 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Miden SDK consists of a Prelude (intrinsic functions for VM opr, stdlib) and transaction kernel API for the Miden rollup
-miden-sdk = { git = "https://github.com/0xPolygonMiden/compiler", rev = "10a05d8fa76106325e2497c2d1b10f1042c77340" }
+{% if compiler_path %}
+miden-sdk = { path = "{{ compiler_path }}/sdk/sdk" }
+{% elsif compiler_branch %}
+miden-sdk = { git = "https://github.com/0xPolygonMiden/compiler", branch = "{{ compiler_branch }}" }
+{% elsif compiler_rev %}
+miden-sdk = { git = "https://github.com/0xPolygonMiden/compiler", rev = "{{ compiler_rev }}" }
+{% else %}
+miden-sdk = { git = "https://github.com/0xPolygonMiden/compiler" }
+{% endif %}
 # Use a tiny allocator in place of the default one, if we want
 # to make use of types in the `alloc` crate, e.g. String. We
 # don't need that now, but its good information to have in hand.


### PR DESCRIPTION
This PR makes the version of `miden-sdk` used by the generated project configurable in a few different ways. The configuration is controlled from `cargo-miden`. See 0xPolygonMiden/compiler#242 for the commit which adds the configuration.

NOTE: This has to be merged first before the compiler PR which uses it can build properly.