### PR TITLE
Add `dev` profile with disabled panic infra

### DIFF
--- a/account/template/Cargo.toml
+++ b/account/template/Cargo.toml
@@ -29,3 +29,14 @@ opt-level = "z"
 # ensures that panics do not pull in a bunch of standard
 # library code unintentionally
 panic = "abort"
+
+[profile.dev]
+# Explicitly disable panic infrastructure on Wasm, as
+# there is no proper support for them anyway, and it
+# ensures that panics do not pull in a bunch of standard
+# library code unintentionally
+panic = "abort"
+opt-level = 1
+debug-assertions = false
+overflow-checks = false
+debug = true


### PR DESCRIPTION
Ref https://github.com/0xPolygonMiden/compiler/issues/323

The tag `v0.4.0` is set on the https://github.com/0xPolygonMiden/rust-templates/pull/6/commits/2da0448b6fe03e0479f3dbce88cfd80871b74242 commit (this PR) and is used in cargo-miden in https://github.com/0xPolygonMiden/compiler/pull/325