### PR TITLE
fix: switch program template to i32

### DIFF
--- a/account/template/src/lib.rs
+++ b/account/template/src/lib.rs
@@ -12,6 +12,7 @@
 static ALLOC: BumpAlloc = miden::BumpAlloc::new();
 
 // Required for no-std crates
+#[cfg(not(test))]
 #[panic_handler]
 fn my_panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}

--- a/program/inputs.toml
+++ b/program/inputs.toml
@@ -1,0 +1,2 @@
+[inputs]
+stack = [2, 3]

--- a/program/template/src/lib.rs
+++ b/program/template/src/lib.rs
@@ -12,21 +12,20 @@
 static ALLOC: BumpAlloc = miden::BumpAlloc::new();
 
 // Required for no-std crates
+#[cfg(not(test))]
 #[panic_handler]
 fn my_panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-use miden::*;
-
-// Pass up to 16 Felt inputs as entrypoint function parameters.
-// The output is temporarely limited to 1 Felt value
+// Pass up to 16 i32 inputs as entrypoint function parameters.
+// The output is temporarely limited to 1 i32 value
 //
 // NOTE:
 // The name of the entrypoint function is expected to be `entrypoint`. Do not remove the
 // `#[no_mangle]` attribute, otherwise, the rustc will mangle the name and it'll not be recognized
 // by the Miden compiler.
 #[no_mangle]
-pub fn entrypoint(a: Felt, b: Felt) -> Felt {
+pub fn entrypoint(a: i32, b: i32) -> i32 {
     a + b
 }

--- a/program/template/src/lib.rs
+++ b/program/template/src/lib.rs
@@ -8,8 +8,8 @@
 // use alloc::vec::Vec;
 
 // // Global allocator to use heap memory in no-std environment
-#[global_allocator]
-static ALLOC: BumpAlloc = miden::BumpAlloc::new();
+// #[global_allocator]
+// static ALLOC: miden::BumpAlloc = miden::BumpAlloc::new();
 
 // Required for no-std crates
 #[cfg(not(test))]


### PR DESCRIPTION
Although the `Felt` type is working, it should be introduced later (vs. this "hello world" stage) to keep the learning curve less steep since `Felt` needs that any constant value is defined with `felt!` macro. 

The tag `v0.8.0` is set to the last commit of this PR and will be used in the `cargo-miden`.